### PR TITLE
Use quoting workaround for unsigned int column type

### DIFF
--- a/lib/active/dbml.rb
+++ b/lib/active/dbml.rb
@@ -155,6 +155,8 @@ module Active
           return 'datetime'
         when 'INTEGER'
           return 'bigint'
+        when /unsigned/
+          return "\"#{sql_type}\""
         else
           return sql_type
       end


### PR DESCRIPTION
Hello. Thanks for the great gem.

The `unsigned` clause for unsigned interger type columns of MySQL is not officially supported by DBML, and the following workaround with quotations can be used to avoid errors.
https://dbml.dbdiagram.io/docs/#column-settings

So I made the minor modification of quoting sql_type with double quotes when it contains the string unsigned.


Outputs gonna be like this.

#### Before

```
Table sample {
  id bigint unsigned [pk, not null]
}
```

#### After

```
Table sample {
  id "bigint unsigned" [pk, not null]
}
```

On dbdocs, this is how it appeared in the TYPE column :)

<img width="518" alt="image" src="https://github.com/user-attachments/assets/3544101d-5269-4df4-8214-adecb592bcc7">


Please check it out.